### PR TITLE
fix: do not include RULES_SNCSEQ if not supported within configure

### DIFF
--- a/configure/RULES_BUILD
+++ b/configure/RULES_BUILD
@@ -1,4 +1,4 @@
 # This is file included by $(EPICS_BASE)/configure/RULES_FILE_TYPE
 # Needed with older Base which doesn't include $(INSTALL_LOCATION)/cfg/RULES_*
 
-include $(dir $(lastword $(MAKEFILE_LIST)))/RULES_SNCSEQ
+-include $(dir $(lastword $(MAKEFILE_LIST)))/RULES_SNCSEQ


### PR DESCRIPTION
This avoids the error on epics-base 7.0:
- sequencer/configure//RULES_SNCSEQ: No such file or directory