### PR TITLE
Change variable type to accommodate large data storages in sequencer program

### DIFF
--- a/src/seq/seq_snc.h
+++ b/src/seq/seq_snc.h
@@ -113,7 +113,7 @@ struct seqProgram
 	unsigned	numChans;	/* number of db channels */
 	seqSS		*ss;		/* array of state set info structs */
 	unsigned	numSS;		/* number of state sets */
-	unsigned	varSize;	/* # bytes in user variable area */
+	size_t		varSize;	/* # bytes in user variable area */
 	const char	*params;	/* program paramters */
 	unsigned	numEvFlags;	/* number of event flags */
 	seqMask		options;	/* program option mask */


### PR DESCRIPTION
During development of sequencer with large amount of data, we have encountered a warning when size of allocated data structure went over the size of the `varSize` data type. 

As this is only populated from the call to `sizeof` operator in the following location: https://github.com/epics-modules/sequencer/blob/f313d4c2ef47dec28448f125ed68639c5afbcfed/src/snc/gen_tables.c#L290
we propose that data type from this variable is updated to reflect the  return value of the `sizeof` operator. 