### PR TITLE
Fixed gcc -Wstringop-overflow and -Wdeprecated-declarations.

### DIFF
--- a/src/seq/seq_mac.c
+++ b/src/seq/seq_mac.c
@@ -78,7 +78,7 @@ void seqMacEval(PROG *sp, const char *inStr, char *outStr, size_t maxChar)
 
 				DEBUG("Value=%s, ", value);
 
-				strncpy(outStr, value, valLth);
+				strncpy(outStr, value, maxChar);
 				maxChar -= valLth;
 				outStr += valLth;
 			}

--- a/src/snc/seqMain.c
+++ b/src/snc/seqMain.c
@@ -25,7 +25,8 @@ int main(int argc,char *argv[]) {
         seqRegisterSequencerCommands();
         iocsh(0);
     } else {
-        epicsThreadExitMain();
+        // epicsThreadExitMain();
+        while (1) epicsThreadSleep(1);
     }
     return(0);
 }


### PR DESCRIPTION
1st warning:
```
../seq_mac.c: In function ‘seqMacEval’:
../seq_mac.c:81:5: warning: ‘strncpy’ specified bound depends on the length of the 
source argument [-Wstringop-overflow=]
     strncpy(outStr, value, valLth);
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../seq_mac.c:75:14: note: length computed here
     valLth = strlen(value);
```
`seqMacEval` already passes the destination size as the 4th argument `maxChar`, this is clear in various calls:
  - `src/seq/seq_main.c:395`
  - `src/seq/seq_if.c:668`

2nd warning:
```
../../../include/seqMain.c: In function ‘main’:
../../../include/seqMain.c:28:9: warning: ‘epicsThreadExitMain’ is deprecated 
[-Wdeprecated-declarations]
         epicsThreadExitMain();
```
function call has been replaced with a loop+sleep, as the deprecation notice suggest. Similar case exist in `test/validate/seqMain.c`